### PR TITLE
Spell my name correctly.

### DIFF
--- a/src/gamemorrowind.cpp
+++ b/src/gamemorrowind.cpp
@@ -97,7 +97,7 @@ QString GameMorrowind::author() const
 QString GameMorrowind::description() const
 {
   return tr("Adds support for the game Morrowind.\n"
-            "Splash by %1").arg("AnyOldName");
+            "Splash by %1").arg("AnyOldName3");
 }
 
 MOBase::VersionInfo GameMorrowind::version() const


### PR DESCRIPTION
While investigating the source of this plugin for unrelated reasons, I noticed that Sandro had missed a character from my name. This adds it.