### PR TITLE
Downgrade failures to set archives and archive invalidation to warnings

### DIFF
--- a/src/gamemorrowind.cpp
+++ b/src/gamemorrowind.cpp
@@ -106,7 +106,7 @@ QString GameMorrowind::description() const
 
 MOBase::VersionInfo GameMorrowind::version() const
 {
-  return VersionInfo(1, 3, 1, VersionInfo::RELEASE_FINAL);
+  return VersionInfo(1, 4, 0, VersionInfo::RELEASE_FINAL);
 }
 
 bool GameMorrowind::isActive() const

--- a/src/morrowinddataarchives.cpp
+++ b/src/morrowinddataarchives.cpp
@@ -40,7 +40,7 @@ void MorrowindDataArchives::setArchives(const QString &iniFile, const QStringLis
   int writtenCount = 0;
   foreach(const QString &value, list) {
     if (!MOBase::WriteRegistryValue(L"Archives", (key+QString::number(writtenCount)).toStdWString().c_str(), value.toStdWString().c_str(), iniFile.toStdWString().c_str())) {
-      throw MOBase::MyException(QObject::tr("failed to set archive key (errorcode %1)").arg(errno));
+      qWarning("failed to set archives in \"%s\"", qUtf8Printable(iniFile));
     }
 	++writtenCount;
   }

--- a/src/morrowindgameplugins.cpp
+++ b/src/morrowindgameplugins.cpp
@@ -104,7 +104,7 @@ void MorrowindGamePlugins::writeList(const IPluginList *pluginList,
         qCritical("invalid plugin name %s", qUtf8Printable(pluginName));
       } else {
 	    if (!MOBase::WriteRegistryValue(L"Game Files", (key+QString::number(writtenCount)).toStdWString().c_str(), pluginName.toStdWString().c_str(), filePath.toStdWString().c_str())) {
-          throw MOBase::MyException(QObject::tr("failed to set game file key (errorcode %1)").arg(errno));
+          qWarning("failed to set game files in \"%s\"", qUtf8Printable(filePath));
         }
       }
       ++writtenCount;


### PR DESCRIPTION
Some users value the ability to keep INI files as read-only and do not
want to be constantly nagged to clear the read-only status. This allows
them to mostly ignore the nags.