### PR TITLE
Support openmw animation overrides

### DIFF
--- a/src/morrowindmoddatachecker.h
+++ b/src/morrowindmoddatachecker.h
@@ -12,7 +12,7 @@ protected:
   virtual const FileNameSet& possibleFolderNames() const override {
     static FileNameSet result{
       "fonts", "meshes", "music", "shaders", "sound", "textures", "video",
-      "mwse", "distantland", "mits", "icons", "bookart", "splash"
+      "mwse", "distantland", "mits", "icons", "bookart", "splash", "animations"
     };
     return result;
   }


### PR DESCRIPTION
Partial resolution for [MO2 #1609](https://github.com/ModOrganizer2/modorganizer/issues/1609)
Simply adds support for a base directory named `animations`. This is in accordance with the openmw convention of allowing [per-group animation overrides.](https://openmw.readthedocs.io/en/latest/reference/modding/extended.html#per-group-animation-files-support)

One example of such a mod would be:
[Simply Sheathing](https://www.nexusmods.com/morrowind/mods/54221/)
And also:
[Weapon Sheathing](https://www.nexusmods.com/morrowind/mods/46069?tab=files)

Note that `Scripts` directories are not supported as the root directory of such a mod will always contain a valid plugin. 

Unfortunately this is not a complete solution, but since users can now provide arbitrary directories which contain arbitrary file types with openmw, there is not a reliable way to determine if script-related content constitutes a valid data directory other than expecting an omwaddon or omwscripts file to exist in the root.